### PR TITLE
Specify `shell: bash` for Github action steps

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -25,18 +25,22 @@ jobs:
           cache: pip
 
       - name: Install Python packages
+        shell: bash
         run: |-
           make install
 
       - name: Generate product charts
+        shell: bash
         run: |-
           python main.py generate-graphs data/archive.json docs/charts/
 
       - name: Update overview page
+        shell: bash
         run: |-
           python main.py generate-overview data/archive.json docs/charts/ docs/overview.md
 
       - name: Commit and push any new charts
+        shell: bash
         run: |-
           git config user.name "Automated"
           git config user.email "actions@users.noreply.github.com"

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -29,19 +29,23 @@ jobs:
           cache: pip
 
       - name: Install Python packages
+        shell: bash
         run: |-
           make install
 
       - name: Fetch latest data
+        shell: bash
         run: |-
           # Run price fetching and capture change summary (if there is one) into a file.
           python main.py update-price-archive data/products.json data/archive.json | tee commit_msg.txt
 
       - name: Generate timeline
+        shell: bash
         run: |-
           python main.py generate-timeline data/archive.json docs/timeline.md
 
       - name: Commit and push if it changed
+        shell: bash
         run: |-
           git config user.name "Automated"
           git config user.email "actions@users.noreply.github.com"


### PR DESCRIPTION
To ensure we get `set -eo pipefail` behaviour. Without this, pipelines
will continue even if a step fails.